### PR TITLE
added MongoDB Atlas connection string

### DIFF
--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/tech-friends');
+// Added MongoDB Atlas connection string with URL encoded password
+mongoose.connect(process.env.MONGODB_URI || 'mongodb+srv://ccarroll:9F.rR%40J%24EUN%21-Ta%2A@deskspacecluster.1ynlold.mongodb.net/');
 
 module.exports = mongoose.connection;


### PR DESCRIPTION
Changed the MongoDB connection string in config/connection.js to a MongoDB Atlas string instead of a MongoDB Compass string